### PR TITLE
Removed the configuration for Image Preprocessor for the time being

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -37,17 +37,6 @@ update_configs:
       - "dependabot"
       - "security"
 
-  ## image preprocessor
-  - package_manager: "python"
-    directory: "/api/preprocessor/"
-    update_schedule: "live"
-    default_assignees:
-      - "mrsupiri"
-    default_labels:
-      - "dependencies"
-      - "dependabot"
-      - "security"
-
   ## image comparator
   - package_manager: "python"
     directory: "/api/comparator/"


### PR DESCRIPTION
Since the Image Preprocessor is not yet complete, we have no need for the configuration settings for the Dependabot, therefore I removed it.